### PR TITLE
(Re)add 1-partitioning

### DIFF
--- a/src/SphereSurfaceHistogram.jl
+++ b/src/SphereSurfaceHistogram.jl
@@ -2,6 +2,7 @@ module SphereSurfaceHistogram
 
 include("binning.jl")
 export SSHBinner
+export partition_sphere1, partition_sphere2
 export push!, append!, unsafe_append!
 
 #include("Makie.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,7 @@ end
 @testset "SphereSurfaceHistogram.jl" begin
 
     # These should pass without issues
+    # If they don't the binning fails for these edge cases.
     @testset "Edge Cases" begin
         B = SSHBinner(1_000)
         push!(B, [0., 0., 1.])
@@ -48,6 +49,7 @@ end
         @test true
     end
 
+
     @testset "Flat Histogram" begin
         for method in [
             SphereSurfaceHistogram.partition_sphere1,
@@ -56,8 +58,16 @@ end
             for _ in 1:10
                 N = floor(Int64, 1_000_000rand()) + 1_000
                 B = SSHBinner(N, method=method)
-                append!(B, dual_points(B))
-                @test all(B.bins .== 1)
+
+                # dual_points (should) return center positions of bins in order
+                # check if each point maps to the correct bin
+                bin_centers = dual_points(B)
+                center_matched_bin = Bool[]
+                for (i, v) in enumerate(bin_centers)
+                    push!(B, v)
+                    push!(center_matched_bin, B.bins[i] == 1)
+                end
+                @test all(center_matched_bin)
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,11 +49,16 @@ end
     end
 
     @testset "Flat Histogram" begin
-        for _ in 1:10
-            N = floor(Int64, 1_000_000rand()) + 1_000
-            B = SSHBinner(N)
-            append!(B, dual_points(B))
-            @test all(B.bins .== 1)
+        for method in [
+            SphereSurfaceHistogram.partition_sphere1,
+            SphereSurfaceHistogram.partition_sphere2
+        ]
+            for _ in 1:10
+                N = floor(Int64, 1_000_000rand()) + 1_000
+                B = SSHBinner(N, method=method)
+                append!(B, dual_points(B))
+                @test all(B.bins .== 1)
+            end
         end
     end
 end


### PR DESCRIPTION
Currently, the xy-angle phi is partitioned into 2^N segments of arclength 2pi/2^N. This pr allows partitioning with arclength 2pi/N, generating much more square bins.